### PR TITLE
Update Gunicorn settings.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ requests-toolbelt==0.8.0
 scipy==0.19.1
 six==1.10.0
 urllib3==1.22
+gevent==1.3.4

--- a/start.sh
+++ b/start.sh
@@ -15,6 +15,10 @@ if [ ! -f $PROJECT_ROOT/.build ]; then
 fi
 
 cd etabotsite
+NUM_WORKERS=3
+TIMEOUT=120
 exec gunicorn etabotsite.wsgi:application \
     --bind 0.0.0.0:8000 \
-    --workers 3
+    --workers $NUM_WORKERS \
+    --worker-class gevent \
+    --timeout $TIMEOUT


### PR DESCRIPTION
* Update worker timetout to 120s
* Use asynchronized worker class. The default synchronous workers assume that your application is resource-bound in terms of CPU and network bandwidth. Generally this means that your application shouldn’t do anything that takes an undefined amount of time. An example of something that takes an undefined amount of time is a request to the internet. At some point the external network will fail in such a way that clients will pile up on your servers. So, in this sense, any web application which makes outgoing requests to APIs will benefit from an asynchronous worker.

For more about gunicorn worker type and settings, check it here: http://docs.gunicorn.org/en/stable/design.html#choosing-a-worker-type

fixes #13