### PR TITLE
Fix security vulnerability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asn1crypto==0.23.0
 certifi==2017.7.27.1
 cffi==1.11.2
 chardet==3.0.4
-cryptography==2.1.3
+cryptography>=2.3
 defusedxml==0.5.0
 Django==2.0.3
 django-cors-headers==2.1.0


### PR DESCRIPTION
A flaw was found in python-cryptography versions between >=1.9.0 and <2.3. The finalize_with_tag API did not enforce a minimum tag length. If a user did not validate the input length prior to passing it to finalize_with_tag an attacker could craft an invalid payload with a shortened tag (e.g. 1 byte) such that they would have a 1 in 256 chance of passing the MAC check. GCM tag forgeries can cause key leakage.

Update the version to >=2.3