### PR TITLE
Disable pre_save/post_save signal for unit test.

### DIFF
--- a/etabotsite/etabotapp/tests.py
+++ b/etabotsite/etabotapp/tests.py
@@ -1,4 +1,6 @@
+import factory
 from django.test import TestCase
+from django.db.models import signals
 from django.contrib.auth.models import User
 from .models import Project, TMS
 from rest_framework.test import APIClient
@@ -50,6 +52,7 @@ class TMSModelTestCase(TestCase):
                        username=self.username, password=self.password,
                        type=self.type)
 
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def test_model_can_create_a_tms(self):
         """Test the user model can create a tms."""
         old_count = TMS.objects.count()
@@ -61,6 +64,7 @@ class TMSModelTestCase(TestCase):
 class TMSViewTestCase(TestCase):
     """Test suite for the api TMS views."""
 
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def setUp(self):
         """Define the TMS test client and other test variables."""
         user = User.objects.create(username="kimchi", email="kimchi@etabot.ai",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-cors-headers==2.1.0
 django-encrypted-model-fields==0.5.3
 djangorestframework==3.7.7
 djangorestframework-expiring-authtoken
+factory-boy=2.11.1
 gunicorn==19.6.0
 idna==2.5
 jira==1.0.10


### PR DESCRIPTION
When creating TMS object, we check the credential by submitting a request api call to given url before save the TMS object. Given test fake credentials, TMS tests were failing. Disabling pre_save signal in the tests will skip the credential check, hence all the tests are passing.