### PR TITLE
Add gevent to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ djangorestframework==3.7.7
 djangorestframework-expiring-authtoken
 factory-boy==2.11.1
 gunicorn==19.6.0
+gevent==1.3.4
 idna==2.5
 jira==1.0.10
 jsonfield==2.0.2


### PR DESCRIPTION
This is needed for running etabot as docker containers.