### PR TITLE
Estimating all tasks for all projects every midnight (pacific time)

### DIFF
--- a/etabotsite/etabotapp/__init__.py
+++ b/etabotsite/etabotapp/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'etabotapp.apps.EtabotappConfig'

--- a/etabotsite/etabotapp/tasks.py
+++ b/etabotsite/etabotapp/tasks.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from celery import shared_task
+
+@shared_task
+def estimate_all():
+    # Estimate ETA for all tasks
+    tms_set = TMS.objects.all()
+    for tms in tms_set:
+        project_set = Project.objects.all().filter(project_tms_id=tms.id)
+        if project_set:
+            tms_wrapper = TMSlib.TMSWrapper(tms)
+            tms_wrapper.init_ETApredict(project_set)
+            tms_wrapper.estimate_tasks()
+    return True

--- a/etabotsite/etabotapp/views.py
+++ b/etabotsite/etabotapp/views.py
@@ -149,9 +149,7 @@ class EstimateTMSView(APIView):
             tms_wrapper = TMSlib.TMSWrapper(tms)
             tms_wrapper.init_ETApredict(projects_set)
 
-            project_names = []
-            for project in projects_set:
-                project_names.append(project.name)
+            project_names = [project.name for project in project_set]
 
             tms_wrapper.estimate_tasks(project_names)
 

--- a/etabotsite/etabotsite/__init__.py
+++ b/etabotsite/etabotsite/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import, unicode_literals
+from .celery import app as celery_app   
+__all__ = ('celery_app',)

--- a/etabotsite/etabotsite/celery.py
+++ b/etabotsite/etabotsite/celery.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import, unicode_literals 
+import os 
+from celery import Celery 
+from celery.schedules import crontab
+# Set default Django settings
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'etabotsite.settings') 
+app = Celery('etabotapp')   
+# Celery will apply all configuration keys with defined namespace
+app.config_from_object('django.conf:settings')   
+# Load tasks from all registered apps 
+app.autodiscover_tasks()
+
+app.conf.beat_schedule = {
+    'estimate-at-midnight': {
+        'task': 'etabotapp.tasks.estimate_all',
+        'schedule': crontab(hour=8) # Midnight Pacific time is 8am UTC 
+    },
+}
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/etabotsite/etabotsite/settings.py
+++ b/etabotsite/etabotsite/settings.py
@@ -17,6 +17,7 @@ import datetime
 import json
 import logging
 import subprocess
+import urllib
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -272,3 +273,24 @@ if LOCAL_MODE:
 else:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
+
+# AWS Credentials
+AWS_ACCESS_KEY_ID = custom_settings['AWS_ACCESS_KEY_ID']
+AWS_SECRET_ACCESS_KEY = custom_settings['AWS_SECRET_ACCESS_KEY']
+
+# Celery Task Scheduling
+BROKER_URL = 'sqs://{0}:{1}@'.format(
+    urllib.parse.quote(AWS_ACCESS_KEY_ID, safe=''),
+    urllib.parse.quote(AWS_SECRET_ACCESS_KEY, safe='')
+)
+
+BROKER_TRANSPORT_OPTIONS = {
+    'region': 'us-west-2',
+    'polling_interval': 20,
+}
+
+CELERY_ACCEPT_CONTENT = ['application/json']
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_DEFAULT_QUEUE = 'etabotqueue'
+CELERY_RESULT_BACKEND = None # Disabling the results backend


### PR DESCRIPTION
Need to make it so celery is launched when the django server is. It can be launched manually by running
celery -A etabotsite worker -l info
celery -A etabotsite beat -l info
in separate terminals.