### PR TITLE
mods to test job id API with UI

### DIFF
--- a/etabotsite/etabotapp/TMSlib/ETApredict_placeholder.py
+++ b/etabotsite/etabotapp/TMSlib/ETApredict_placeholder.py
@@ -2,8 +2,18 @@
 # uncomment for syntax error for ensuring placeholder is not used 
 
 import logging
+import time
 # import TMSlib.TMS_project as TMS_project
 
+class Measurement():
+    def __init__(self, value):
+        self.value = value
+
+    def lower_estimate(self, confidence_level=0.95):
+        return self.value / 1.2
+
+    def higher_estimate(self, confidence_level=0.95):
+        return self.value * 1.2
 
 class ETAengine():
     def __init__(self):
@@ -29,8 +39,12 @@ class ETApredict():
             self.get_projects()
 
     def generate_task_list_view_with_ETA(
-            self, project_names=None, include_active_sprints=False):
+            self,
+            project_names=None,
+            include_active_sprints=False,
+            **extra_kwargs):
         self.TMS_interface.connect_to_TMS()
+        time.sleep(5)
         logging.info('placeholder ETAs have been generated')
 
     def get_projects(self):
@@ -103,5 +117,10 @@ class ETApredict():
             {"start": "2018-09-14", "end": "2018-09-21"}
 
         ]
+
+        self.user_velocity_per_project = {
+            'Project Cheburashka': Measurement(1.2),
+            'Project Buckwheat': Measurement(2.3)
+        }
 
         logging.debug('get_projects finished')

--- a/etabotsite/etabotapp/views.py
+++ b/etabotsite/etabotapp/views.py
@@ -90,7 +90,7 @@ def activate(request):
 @permission_classes([])
 def email_verification(request):
     logging.debug('activate API started')
-    post_data = json.loads(request.body.decode(encoding='utf-8'))
+    post_data = json.loads(request.body)
     user = User.objects.get(pk=post_data['uid'])
     body = dict()
 
@@ -401,7 +401,7 @@ class EstimateTMSView(APIView):
         post_data = {}
         if request.body:
             logging.debug('request.body: {}'.format(request.body))
-            post_data = json.loads(request.body.decode(encoding='utf-8'))
+            post_data = json.loads(request.body)
 
         logging.debug('post_data: {}'.format(post_data))
         logging.debug('request.query_params: "{}"'.format(

--- a/etabotsite/etabotapp/views.py
+++ b/etabotsite/etabotapp/views.py
@@ -59,7 +59,7 @@ def index(request, path='', format=None):
 @permission_classes([])
 def activate(request):
     logging.debug('activate API started')
-    post_data = json.loads(request.body.decode(encoding='utf-8'))
+    post_data = json.loads(request.body)
     logging.debug('user activate post_data: "{}"'.format(post_data))
     code = ActivationProcessor.activate_user(post_data['token'])
     body = dict()

--- a/etabotsite/etabotapp/views.py
+++ b/etabotsite/etabotapp/views.py
@@ -401,7 +401,7 @@ class EstimateTMSView(APIView):
         post_data = {}
         if request.body:
             logging.debug('request.body: {}'.format(request.body))
-            post_data = json.loads(request.body)
+            post_data = json.loads(request.body.decode(encoding='utf-8'))
 
         logging.debug('post_data: {}'.format(post_data))
         logging.debug('request.query_params: "{}"'.format(


### PR DESCRIPTION
@ShanshanHe , with these modifications I was able to test your PR. please review and merge as necessary.

test results: 
able to push button "Update ETAs" in UI and receive response  like this: "{"5":"96183809-5073-4ec0-8d85-9a1b0e8264cf"}". 
In the backend I saw successful celery job completion.

Haven't tested  this route yet:  url(r'^api/estimate-status/tms/(?P<id>.+)/$',
        EstimationStatusView.as_view(), name="estimation_status"),
- will wait for the documentation for UI changes first.